### PR TITLE
Multi-Version V1: Add required Java versions in accordance to each Minecraft version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,11 +23,15 @@ jobs:
         with:
           fetch-depth: 10
 
-      - name: Set up JDK 17
+      - name: Set up JDK 8, 16, 17, 21
         uses: actions/setup-java@v4
         with:
-          java-version: 21
           distribution: temurin
+          java-version: |
+            8
+            16
+            17
+            21
 
       - uses: actions/cache@v4
         with:


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Adds all the Java versions in accordance to what each Minecraft version requires. This should stop the Gradle build from failing.

## How to test
<!-- Provide steps to test this PR -->
Run a build against this PR (https://github.com/Tellinq/OneConfigExampleMod/actions/runs/15854781644 is one I’m running right now)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
None needed