### PR TITLE
Kotlin Multi Version: Fix <=1.12.2 Forge entrypoints not working

### DIFF
--- a/src/main/kotlin/org/polyfrost/example/ExampleEntrypoint.kt
+++ b/src/main/kotlin/org/polyfrost/example/ExampleEntrypoint.kt
@@ -55,6 +55,8 @@ class ExampleEntrypoint
 
     //#if FABRIC
     //$$ override
+    //#elseif FORGE && MC <= 1.12.2
+    @Mod.EventHandler
     //#endif
     fun onInitialize(
         //#if FORGE-LIKE
@@ -70,6 +72,8 @@ class ExampleEntrypoint
 
     //#if FABRIC
     //$$ override
+    //#elseif FORGE && MC <= 1.12.2
+    @Mod.EventHandler
     //#endif
     fun onInitializeClient(
         //#if FORGE-LIKE
@@ -89,6 +93,8 @@ class ExampleEntrypoint
 
     //#if FABRIC
     //$$ override
+    //#elseif FORGE && MC <= 1.12.2
+    @Mod.EventHandler
     //#endif
     fun onInitializeServer(
         //#if FORGE-LIKE


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
On <=1.12.2 Forge, @Mod.EventHandler was not added. As a result, the examplemod would not load.

## How to test
<!-- Provide steps to test this PR -->
1. Launch the game
2. The mod should now be completely loaded.

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
No documentation update is required